### PR TITLE
Add interruptions to state machine

### DIFF
--- a/state_machine/interdrone.py
+++ b/state_machine/interdrone.py
@@ -1,0 +1,137 @@
+"""
+Contains the Interdrone class, which handles interdrone communication messages
+and allows for the cancellation and starting of states based on message data.
+"""
+
+import asyncio
+from asyncio import Task
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    # If this import is left outside of the TYPE_CHECKING check,
+    # it causes a circular import.
+    from state_machine.states.state import State
+
+
+class Interdrone:
+    """
+    Handles interdrone communication messages and allows
+    for the cancellation and starting of states based on message data.
+
+    Attributes
+    ----------
+    _current_task : Task | None
+        The current task being executed.
+    _current_state : State | None
+        The current state being executed in the state machine.
+    _restart_callback : Callable[[State | None], Awaitable[None]] | None
+        The callback function to be called when the state machine needs to be restarted.
+    """
+
+    def __init__(self):
+        self._current_task: Task | None = None
+        self._current_state: "State | None" = None
+        self._restart_callback: Callable[["State | None"], Awaitable[None]] | None = None
+
+    def register_state_machine(self, callback: Callable[["State | None"], Awaitable[None]]) -> None:
+        """
+        Registers a state machine with the run() method. This allows for the
+        state machine to be restarted from the Interdrone object with any state.
+
+        Parameters
+        ----------
+        callback : Callable[[State | None], Awaitable[None]]
+            The callback function to be called when the state machine needs to be restarted.
+        """
+        self._restart_callback = callback
+
+    def update_task(self, task: Task) -> None:
+        """
+        Updates the current asyncio task being executed.
+        This should be a Task of a state being executed in the state machine.
+
+        Parameters
+        ----------
+        task : Task
+            The task to update the current task to.
+        """
+        self._current_task = task
+
+    def update_state(self, state: "State") -> None:
+        """
+        Updates the current state being executed in the state machine.
+
+        Parameters
+        ----------
+        state : State
+            The state to update the current state to.
+        """
+        self._current_state = state
+
+    async def cancel_state(self) -> None:
+        """
+        Cancels the current state being executed.
+        If the current state is in an atomic context,
+        waits for the lock to release before cancelling.
+
+        Raises
+        ------
+        RuntimeError
+            If there is no running state/task to cancel.
+        """
+        if not self._current_state or not self._current_task:
+            raise RuntimeError("No running state/task to cancel")
+
+        # Check if the state is in an atomic context before cancelling
+        # If so, wait for the lock to release then cancel task
+        task_to_cancel = self._current_task
+        async with self._current_state.atomic:
+            task_to_cancel.cancel()
+            self._current_state = None
+            self._current_task = None
+
+        # We need to wait for the task to actually be cancelled before
+        # doing anything useful, which we can do by awaiting the task after
+        # it has already been scheduled for cancellation
+        # This will always raise the CancelledError
+        try:
+            await task_to_cancel
+        except asyncio.CancelledError:
+            pass
+
+    async def restart_state_machine(self, state: "State | None") -> None:
+        """
+        Restarts the state machine with the given state, or if none is
+        provided, the last state that was running
+
+        Parameters
+        ----------
+        state : State | None
+            The state to restart the state machine with.
+
+        Raises
+        ------
+        RuntimeError
+            If there is a running task or the state machine has not been registered.
+        """
+        if self._current_state or self._current_task:
+            raise RuntimeError("Cannot restart state while a task is running")
+
+        if not self._restart_callback:
+            raise RuntimeError("Cannot restart state machine without a registered callback")
+
+        # Start the restart callback as a separate task but do not wait for it
+        asyncio.ensure_future(self._restart_callback(state))
+
+    def read(self) -> None:
+        """
+        Read an message.
+        """
+        raise NotImplementedError
+
+    def send(self) -> None:
+        """
+        Send a message.
+        """
+        raise NotImplementedError

--- a/state_machine/state_machine.py
+++ b/state_machine/state_machine.py
@@ -1,11 +1,12 @@
 """Defines the StateMachine class."""
 
 import asyncio
-from asyncio import Task
 import logging
+from asyncio import Task
 
 from state_machine.drone import Drone
 from state_machine.flight_settings import FlightSettings
+from state_machine.interdrone import Interdrone
 from state_machine.states import State
 
 
@@ -21,21 +22,32 @@ class StateMachine:
         The drone this state machine controls.
     flight_settings : FlightSettings
         The flight settings this flight uses.
+    interdrone : Interdrone
+        The interdrone object this state machine uses.
     run_task : Task[None] | None
         The task that runs through the states in a loop. If the state machine
         is not running, this should be None.
 
     Methods
     -------
-    __init__(initial_state: State, drone: Drone, flight_settings: FlightSettings)
+    __init__(
+        initial_state: State,
+        drone: Drone,
+        flight_settings: FlightSettings,
+        interdrone: Interdrone,
+    )
         Initialize a new state machine object.
     run(initial_state: State | None) -> Awaitable[None]
         Run the flight code specific to each state until completion.
-    cancel() -> Awaitable[None]
-        Cancel the currently running state loop.
     """
 
-    def __init__(self, initial_state: State, drone: Drone, flight_settings: FlightSettings):
+    def __init__(
+        self,
+        initial_state: State,
+        drone: Drone,
+        flight_settings: FlightSettings,
+        interdrone: Interdrone,
+    ):
         """
         Initialize a new state machine object.
 
@@ -48,11 +60,16 @@ class StateMachine:
             The drone this state machine will control.
         flight_settings : FlightSettings
             The flight settings to use.
+        interdrone : Interdrone
+            The interdrone communication object to use to coordinate.
         """
         self.current_state: State | None = initial_state
         self.drone: Drone = drone
         self.flight_settings: FlightSettings = flight_settings
+        self.interdrone: Interdrone = interdrone
         self.run_task: Task[None] | None = None
+
+        self.interdrone.register_state_machine(self.run)
 
     async def run(self, initial_state: State | None = None) -> None:
         """Run the flight code specific to each state until completion.
@@ -69,10 +86,19 @@ class StateMachine:
         if initial_state is not None:
             self.current_state = initial_state
 
+        if self.current_state is None:
+            raise ValueError("No state to run")
+
         run_task: Task[None] = asyncio.ensure_future(self._run())
+        self.interdrone.update_task(run_task)
         self.run_task = run_task
         logging.info("State Machine started")
-        await run_task
+
+        try:
+            await run_task
+        except asyncio.CancelledError:
+            logging.info("State Machine cancelled")
+
         if self.run_task is not None:
             self.run_task = None
             logging.info("State Machine complete")
@@ -80,13 +106,5 @@ class StateMachine:
     async def _run(self) -> None:
         """Runs the flight code specific to each state until completion."""
         while self.current_state:
+            self.interdrone.update_state(self.current_state)
             self.current_state = await self.current_state.run()
-
-    def cancel(self) -> None:
-        """Cancel the currently running state loop.."""
-        if self.run_task is None:
-            return
-
-        self.run_task.cancel()
-        self.run_task = None
-        logging.info("State Machine canceled")

--- a/state_machine/states/impl/calc_scan_path_impl.py
+++ b/state_machine/states/impl/calc_scan_path_impl.py
@@ -3,20 +3,19 @@
 import asyncio
 import logging
 
+import flight.pathfinding.path_subdivision as gotoDiv
 from flight.extract_gps import extract_gps
+from flight.pathfinding.node_generation import Connection, Field, Mine, Node
+from flight.pathfinding.path_calculation import Graph
+from flight.pathfinding.utils import seen_by_drone
 from state_machine.state_tracker import (
-    update_state,
     update_drone,
     update_flight_settings,
+    update_state,
 )
-from state_machine.states.state import State
-from state_machine.states.calc_scan_path import CalcScanPath
 from state_machine.states.app_share import AppShare
-
-import flight.pathfinding.path_subdivision as gotoDiv
-from flight.pathfinding.node_generation import Node, Mine, Field, Connection
-from flight.pathfinding.path_calculation import Graph
-from flight.pathfinding.utils import seen_by_drone 
+from state_machine.states.calc_scan_path import CalcScanPath
+from state_machine.states.state import State
 
 
 async def run(self: CalcScanPath) -> State:
@@ -50,20 +49,22 @@ async def run(self: CalcScanPath) -> State:
         update_nodes()
 
         self.drone.start_node, self.drone.end_nodes = place_start_end_nodes()
-        newGraph=Graph(self.drone.field.nodeGraph)
-        nodeList=newGraph.shortest_path(start,end)
+        newGraph = Graph(self.drone.field.nodeGraph)
+        nodeList = newGraph.shortest_path(start, end)
 
         goto_coords, seg_path = gotoDiv.generate_goto_points(nodeList)
 
         # This relies on the ID's for the drones being 0-3 and not 1-4 CHANGE IF THAT ISN'T THE CASE
-        divied_goto = goto_coords[id*len(divied_goto)/4:(id+1)*len(divied_goto)/4]
-        divied_seg = seg_path[id*len(seg_path)/4:(id+1)*len(seg_path)/4]
+        divied_goto = goto_coords[id * len(divied_goto) / 4 : (id + 1) * len(divied_goto) / 4]
+        divied_seg = seg_path[id * len(seg_path) / 4 : (id + 1) * len(seg_path) / 4]
 
-        pruned_goto = seen_by_drone.remove_extra_coords(self.drone.seen_tracker, divied_goto, divied_seg, self.drone.get_cam_size())
+        pruned_goto = seen_by_drone.remove_extra_coords(
+            self.drone.seen_tracker, divied_goto, divied_seg, self.drone.get_cam_size()
+        )
         self.drone.updateTasks(pruned_goto)
         # Add CalcScanPath code here
-        
-        return AppShare(self.drone, self.flight_settings)
+
+        return AppShare(self.drone, self.flight_settings, self.interdrone)
     except asyncio.CancelledError as ex:
         logging.error("CalcScanPath state canceled")
         raise ex

--- a/state_machine/states/impl/drone_share_impl.py
+++ b/state_machine/states/impl/drone_share_impl.py
@@ -5,13 +5,13 @@ import logging
 
 from flight.extract_gps import extract_gps
 from state_machine.state_tracker import (
-    update_state,
     update_drone,
     update_flight_settings,
+    update_state,
 )
-from state_machine.states.state import State
-from state_machine.states.drone_share import DroneShare
 from state_machine.states.calc_scan_path import CalcScanPath
+from state_machine.states.drone_share import DroneShare
+from state_machine.states.state import State
 
 
 async def run(self: DroneShare) -> State:
@@ -42,8 +42,8 @@ async def run(self: DroneShare) -> State:
         update_flight_settings(self.flight_settings)
         logging.info("DroneShare state running")
 
-        for i in range(1,5):
-            if (self.drone.id == i):
+        for i in range(1, 5):
+            if self.drone.id == i:
                 # Broadcast new minedata and new sight data
                 broadcast()
             else:
@@ -51,7 +51,7 @@ async def run(self: DroneShare) -> State:
                 recieve()
         # Add drone share code here
 
-        return CalcScanPath(self.drone, self.flight_settings)
+        return CalcScanPath(self.drone, self.flight_settings, self.interdrone)
     except asyncio.CancelledError as ex:
         logging.error("DroneShare state canceled")
         raise ex

--- a/state_machine/states/impl/initial_calc_scan_path_impl.py
+++ b/state_machine/states/impl/initial_calc_scan_path_impl.py
@@ -3,19 +3,19 @@
 import asyncio
 import logging
 
+import flight.pathfinding.path_subdivision as gotoDiv
 from flight.extract_gps import extract_gps
+from flight.pathfinding.node_generation import Connection, Field, Mine, Node
+from flight.pathfinding.path_calculation import Graph
 from state_machine.state_tracker import (
-    update_state,
     update_drone,
     update_flight_settings,
+    update_state,
 )
-from state_machine.states.state import State
 from state_machine.states.initial_calc_scan_path import InitialCalcScanPath
 from state_machine.states.scan import Scan
+from state_machine.states.state import State
 
-import flight.pathfinding.path_subdivision as gotoDiv
-from flight.pathfinding.node_generation import Node, Mine, Field, Connection
-from flight.pathfinding.path_calculation import Graph
 
 async def run(self: InitialCalcScanPath) -> State:
     """
@@ -48,18 +48,18 @@ async def run(self: InitialCalcScanPath) -> State:
         update_nodes()
 
         self.drone.start_node, self.drone.end_nodes = place_start_end_nodes()
-        newGraph=Graph(self.drone.field.nodeGraph)
-        nodeList=newGraph.shortest_path(start_node,end_nodes)
+        newGraph = Graph(self.drone.field.nodeGraph)
+        nodeList = newGraph.shortest_path(start_node, end_nodes)
 
         goto_coords, seg_path = gotoDiv.generate_goto_points(nodeList)
 
         # This relies on the ID's for the drones being 0-3 and not 1-4 CHANGE IF THAT ISN'T THE CASE
-        divied_goto = goto_coords[id*len(divied_goto)/4:(id+1)*len(divied_goto)/4]
+        divied_goto = goto_coords[id * len(divied_goto) / 4 : (id + 1) * len(divied_goto) / 4]
 
         self.drone.updateTasks(divied_goto)
         # Add InitialCalcScanPath code here
 
-        return Scan(self.drone, self.flight_settings)
+        return Scan(self.drone, self.flight_settings, self.interdrone)
     except asyncio.CancelledError as ex:
         logging.error("InitialCalcScanPath state canceled")
         raise ex

--- a/state_machine/states/impl/recall_impl.py
+++ b/state_machine/states/impl/recall_impl.py
@@ -5,13 +5,13 @@ import logging
 
 from flight.extract_gps import extract_gps
 from state_machine.state_tracker import (
-    update_state,
     update_drone,
     update_flight_settings,
+    update_state,
 )
-from state_machine.states.state import State
-from state_machine.states.recall import Recall
 from state_machine.states.land import Land
+from state_machine.states.recall import Recall
+from state_machine.states.state import State
 
 
 async def run(self: Recall) -> State:
@@ -44,7 +44,7 @@ async def run(self: Recall) -> State:
 
         self.drone.recall()
 
-        return Land(self.drone, self.flight_settings)
+        return Land(self.drone, self.flight_settings, self.interdrone)
     except asyncio.CancelledError as ex:
         logging.error("Recall state canceled")
         raise ex

--- a/state_machine/states/impl/scan_impl.py
+++ b/state_machine/states/impl/scan_impl.py
@@ -5,13 +5,13 @@ import logging
 
 from flight.extract_gps import extract_gps
 from state_machine.state_tracker import (
-    update_state,
     update_drone,
     update_flight_settings,
+    update_state,
 )
-from state_machine.states.state import State
-from state_machine.states.scan import Scan
 from state_machine.states.drone_share import DroneShare
+from state_machine.states.scan import Scan
+from state_machine.states.state import State
 
 
 async def run(self: Scan) -> State:
@@ -45,7 +45,7 @@ async def run(self: Scan) -> State:
         self.drone.completeTasks()
         # Add scan code here
 
-        return DroneShare(self.drone, self.flight_settings)
+        return DroneShare(self.drone, self.flight_settings, self.interdrone)
     except asyncio.CancelledError as ex:
         logging.error("Takeoff state canceled")
         raise ex

--- a/state_machine/states/impl/start_impl.py
+++ b/state_machine/states/impl/start_impl.py
@@ -4,9 +4,9 @@ import asyncio
 import logging
 
 from state_machine.state_tracker import (
-    update_state,
     update_drone,
     update_flight_settings,
+    update_state,
 )
 from state_machine.states.start import Start
 from state_machine.states.state import State
@@ -42,7 +42,7 @@ async def run(self: Start) -> State:
         await self.drone.arm()
 
         logging.info("Start state complete")
-        return Takeoff(self.drone, self.flight_settings)
+        return Takeoff(self.drone, self.flight_settings, self.interdrone)
     except asyncio.CancelledError as ex:
         logging.error("Start state canceled")
         raise ex

--- a/state_machine/states/impl/takeoff_impl.py
+++ b/state_machine/states/impl/takeoff_impl.py
@@ -5,13 +5,13 @@ import logging
 
 from flight.extract_gps import extract_gps
 from state_machine.state_tracker import (
-    update_state,
     update_drone,
     update_flight_settings,
+    update_state,
 )
+from state_machine.states.land import Land
 from state_machine.states.state import State
 from state_machine.states.takeoff import Takeoff
-from state_machine.states.land import Land
 
 
 async def run(self: Takeoff) -> State:
@@ -48,7 +48,7 @@ async def run(self: Takeoff) -> State:
         )
         await self.drone.takeoff(takeoff_altitude)
 
-        return InitialCalcScanPath(self.drone, self.flight_settings)
+        return InitialCalcScanPath(self.drone, self.flight_settings, self.interdrone)
     except asyncio.CancelledError as ex:
         logging.error("Takeoff state canceled")
         raise ex

--- a/state_machine/states/state.py
+++ b/state_machine/states/state.py
@@ -1,11 +1,13 @@
 """Defines the State abstract base class, which all states should inherit from."""
 
-from abc import ABC, abstractmethod
 import logging
+from abc import ABC, abstractmethod
+from asyncio import Lock
 from typing import Awaitable
 
 from state_machine.drone import Drone
 from state_machine.flight_settings import FlightSettings
+from state_machine.interdrone import Interdrone
 
 
 class State(ABC):
@@ -20,10 +22,12 @@ class State(ABC):
         The drone to which this state is bound.
     _flight_settings : FlightSettings
         The flight settings to which this state is bound.
+    _interdrone : Interdrone
+        The interdrone object that allows the state to send messages.
 
     Methods
     -------
-    __init__(drone: Drone, flight_settings: FlightSettings) -> None
+    __init__(drone: Drone, flight_settings: FlightSettings, interdrone: Interdrone) -> None
         Initialize a new state object.
 
     name() -> str
@@ -35,11 +39,16 @@ class State(ABC):
     flight_settings() -> FlightSettings
         Get the flight settings this state is bound to.
 
+    interdrone() -> Interdrone
+        Get the interdrone object this state is bound to.
+
     run() -> Awaitable["State"]
         Run this state.
     """
 
-    def __init__(self, drone: Drone, flight_settings: FlightSettings) -> None:
+    def __init__(
+        self, drone: Drone, flight_settings: FlightSettings, interdrone: Interdrone
+    ) -> None:
         """
         Initialize a new state object.
 
@@ -49,9 +58,21 @@ class State(ABC):
             The drone to bind this state to.
         flight_settings : FlightSettings
             The drone to bind this state to.
+        interdrone : Interdrone
+            The interdrone communication object to bind this state to.
+
+        Attributes
+        ----------
+        atomic : Lock
+            A lock that can be used to make an atomic section of code,
+            where it cannot be cancelled while it is running.
         """
         self._drone: Drone = drone
         self._flight_settings: FlightSettings = flight_settings
+        self._interdrone: Interdrone = interdrone
+
+        self.atomic = Lock()
+
         logging.info("Entering %s state", self.name)
 
     @property
@@ -89,6 +110,18 @@ class State(ABC):
             The flight settings object this state is bound to.
         """
         return self._flight_settings
+
+    @property
+    def interdrone(self) -> Interdrone:
+        """
+        Get the interdrone object this state is bound to.
+
+        Returns
+        -------
+        Interdrone
+            The interdrone object this state is bound to.
+        """
+        return self._interdrone
 
     @abstractmethod
     def run(self) -> Awaitable["State"] | Awaitable[None]:

--- a/state_machine/tests/restart_test.py
+++ b/state_machine/tests/restart_test.py
@@ -1,0 +1,136 @@
+"""
+This module contains a test for the cancel and restart functionality of the state machine.
+"""
+
+import asyncio
+import logging
+from typing import Awaitable
+
+from state_machine.drone import Drone
+from state_machine.flight_settings import FlightSettings
+from state_machine.interdrone import Interdrone
+from state_machine.state_machine import StateMachine
+from state_machine.states import State
+
+
+class TestState1(State):
+    """
+    A test state that sleeps for 5 seconds and then transitions to TestState2.
+    """
+
+    def run(self) -> Awaitable[State]:
+        return self.run_callable()
+
+    async def run_callable(self) -> State:
+        """
+        Sleeps for 5 seconds and then transitions to TestState2.
+        """
+        await asyncio.sleep(5)
+        return TestState2(self._drone, self._flight_settings, self._interdrone)
+
+
+class TestState2(State):
+    """
+    A test state that sleeps for 10 seconds inside of an atomic section,
+    sleeps for 10 seconds outside of the atomic section.
+    """
+
+    def run(self) -> Awaitable[None]:
+        return self.run_callable()
+
+    async def run_callable(self) -> None:
+        """
+        Runs the state logic: enters an atomic section, sleeps for 10 seconds,
+        exits the atomic section, and then sleeps for 10 seconds before returning.
+        """
+        # Enter an atomic section using async with self.atomic
+        async with self.atomic:
+            logging.info("State2: Entering atomic section")
+            await asyncio.sleep(10)
+
+        logging.info("State2: Exiting atomic section")
+        await asyncio.sleep(10)
+        return
+
+
+async def cancel_and_restart_task(
+    drone: Drone, flight_settings: FlightSettings, interdrone: Interdrone
+) -> None:
+    """
+    This task seeks to cover every case of where the state machine would be cancelled and restarted.
+
+    First, the state machine is cancelled while TestState2 is inside of its atomic section.
+    The state machine is then restarted with a start state of TestState1.
+    Then, the state machine is cancelled again, outside of the atomic section.
+    The state machine is restarted again, but this time is not given a start state.
+    This means that it will restart with the last running state, which will be TestState2.
+    The state machine is then allowed to run to completion.
+    """
+    logging.info("Cancel task: Running cancel and restart task")
+    await asyncio.sleep(11)
+    logging.info("Cancel task: Cancelling state")
+    await interdrone.cancel_state()
+    logging.info("Cancel task: Restarting state machine and starting State1 again")
+    await interdrone.restart_state_machine(
+        TestState1(drone, flight_settings, interdrone)
+    )
+    logging.info(
+        "Cancel task: State machine restarted and State1 started again, "
+        "waiting before cancelling again"
+    )
+    await asyncio.sleep(18)
+    logging.info("Cancel task: Cancelling state again")
+    await interdrone.cancel_state()
+    logging.info("Cancel task: Restarting state machine without given state")
+    await interdrone.restart_state_machine(None)
+    logging.info(
+        "Cancel task: State machine restarted without given state. "
+        "Awaiting state machine completion..."
+    )
+    while interdrone._current_task is None:  # pylint: disable=protected-access
+        # Wait for task to be set
+        await asyncio.sleep(0.1)
+    if interdrone._current_task is not None:  # pylint: disable=protected-access
+        # Wait for state machine task to complete
+        await interdrone._current_task  # pylint: disable=protected-access
+    logging.info("Cancel task: Done.")
+
+
+async def start_test_task(
+    drone: Drone, flight_settings: FlightSettings, interdrone: Interdrone
+) -> None:
+    """
+    This task starts the state machine with a start state of TestState1,
+    then returns when the state machine is first cancelled.
+    """
+    start_state = TestState1(drone, flight_settings, interdrone)
+    state_machine = StateMachine(start_state, drone, flight_settings, interdrone)
+
+    try:
+        await state_machine.run()
+    except asyncio.CancelledError:
+        logging.info("Test: State machine cancelled")
+
+    logging.info("Test: Done.")
+
+
+async def start_test() -> None:
+    """
+    Initializes the test by creating a drone, flight settings, and interdrone object,
+    then starts the test task and the cancel-and-restart task concurrently with gather.
+    """
+    drone: Drone = Drone()
+    flight_settings: FlightSettings = FlightSettings()
+    interdrone: Interdrone = Interdrone()
+
+    drone.use_settings(flight_settings.sim_mode)
+
+    await asyncio.gather(
+        start_test_task(drone, flight_settings, interdrone),
+        cancel_and_restart_task(drone, flight_settings, interdrone),
+    )
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(start_test())


### PR DESCRIPTION
Adds the barebone Interdrone class which is passed to all classes and allows for both access of interdrone commands and functionality and the ability to cancel and restart states.

The ability to be in a "atomic" section of code in states is available by using `async with self.atomic`, which is a new attribute added to the base state.

Resolves #16 